### PR TITLE
Move COMMUNICATIONS file

### DIFF
--- a/COMMUNICATIONS.md
+++ b/COMMUNICATIONS.md
@@ -1,0 +1,54 @@
+# OpenSearch Project Communication
+
+- [Overview](#overview)
+- [Slack](#slack)
+  - [Getting Started](#getting-started)
+  - [Workspace Channels](#workspace-channels)
+  - [Tips](#tips)
+
+## Overview
+
+The purpose of this document is to provide information regarding the communication channels for the OpenSearch Project. All communication is subject to the [OpenSearch Code of Conduct](CODE_OF_CONDUCT.md). Please see [CONTRIBUTING](CONTRIBUTING.md) if you're interested in contributing to the project.
+
+## Slack
+
+OpenSearch has a workspace on [Slack](https://opensearch.slack.com) to provide open communication channels for anyone interested in OpenSearch.
+
+The following guidelines include a Getting Started for steps to register and setup the workspace along with tips for using the workspace. Please read through these guidelines carefully and thoroughly.
+
+### Getting Started
+
+_Join Workspace_
+
+  * Visit the [slack landing page](https://opensearch.org/slack.html) on OpenSearch.org for information on registering your account. You will be required to enroll in two-factor authentication to ensure the best possible security of your account.
+
+_Update Profile_
+
+  * You may add your interests or keywords in the “What I do” section of your profile along with your Title and Company/Organization. This helps participants network and connect with each other by common interests.
+  * Feel free to update your profile photo to something unique to you. All profile photos are subject to the [OpenSearch Code of Conduct](CODE_OF_CONDUCT.md) policies.
+  * Optionally share your pronouns by adding them to the end of your Full Name in your profile. This way other participants will be able to see them and be respectful to your communication preferences. Please also be respectful of other participants’ pronouns.
+
+### Workspace Channels
+
+After you join OpenSearch workspace you will be automatically added to the following channels:
+
+  * **#announcements** - Read only channel for overall project announcements. This may include critical security issues, releases, milestones or general information related to the OpenSearch Project community.
+  * **#general** - a channel for asking general questions. Based on the question or discussion users will mostly likely be directed to more specific channels based on the topics of interest.
+  * **#random** - consider this the water cooler in a face to face workspace. Feel free to introduce yourself to the community, share what you’re working on, or what you’re excited about learning with OpenSearch.
+
+There are dedicated channels for the following (note that participants might be directed to more specific channels based on the nature of the discussion):
+
+  * **#admin-requests** - slack related feature requests and questions for the administration team.
+  * **#dev** - primary channel for development questions. This is a good place to start for participants interested in OpenSearch development but are not sure which channels to join.
+  * **#core** -  primary channel for core OpenSearch. General questions and discussions about the core can be asked here.
+  * **#dashboards** - primary channel for Dashboards. General questions and discussions about dashboards can be asked here.
+  * **#infra** - primary channel for infra. General discussions, questions, or infra requests can be posted here.
+
+### Tips
+
+  * Try to keep communications in the open - not only does this facilitate better sharing of information but back channeled discussions are not retained for search among other community members.
+  * Slack conversations are not searchable outside the workspace. For this reason we encourage using the [OpenSearch Discussion Forum](https://forum.opensearch.org) for technical support discussions or, at least, open a summary discussion on the forum so useful findings can be shared with the rest of the community.
+  * Keep discussions organized - use threads to respond to comments inline instead of posting to the entire channel.
+  * Expect asynchronous response time - do not assume immediate response time, or possibly any response at all. This is a community driven communication tool with participants in different time zones. The workspace should not be treated as a formal support or training tool.
+  * Protecting IP and legally protected information is your responsibility, this is a public forum. Don’t presume anything said here will remain private.
+  * **DO NOT** post CVEs or Security issues publicly. See [SECURITY](SECURITY.md) for guidelines on handling security issues.


### PR DESCRIPTION
### Description
Move the COMMUNICATIONS.md file from .github repo to the community repo; this is a file that covers community norms and activities rather than code so a better long-term place is in the community repo. 

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
