### PR TITLE
Additional maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @krisfreedain @nknize
+*   @krisfreedain @nknize @dimwetoth @jhmcintyre @nateynateynate

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,4 +7,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Maintainer       | GitHub ID                                           | Affiliation |
 | ---------------- | --------------------------------------------------- | ----------- |
 | Kris Freedain    | [krisfreedain](https://github.com/krisfreedain)     | Amazon      |
-| Nick Knize       | [nknize](https://github.com/nknize)                 | Amazon      |
+| Nick Knize       | [nknize](https://github.com/nknize)                 | Lucenia     |
+| Daryll Swager    | [dimwetoth](https://github.com/dimwetoth)           | Amazon      |
+| James McIntyre   | [jhmcintyre](https://github.com/jhmcintyre)         | Amazon      |
+| Nate Boot        | [nateynateynate](https://github.com/nateynateynate) | Amazon      |


### PR DESCRIPTION
### Description
Adding Daryll Swager, James McIntyre, Nate Boot as additional maintainers

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
