### PR TITLE
OpenSearch Session Level Guide

### DIFF
--- a/events/session-level-guide.md
+++ b/events/session-level-guide.md
@@ -1,0 +1,46 @@
+
+
+### OpenSearch Events: Session Level Guide
+
+OpenSearch presentations are categorized into 100, 200, and 300 levels to help attendees choose sessions that match their expertise. Each level indicates the depth of technical knowledge required to effectively engage with the content.
+
+### 100-Level: Core Concepts, Fundamentals & Community Insights
+
+Target audience: Newcomers to the OpenSearch community, including developers, advocates, students, and operations professionals starting their journey.
+
+Content focus: Core OpenSearch concepts, basic setup, fundamental operations, and learnings from the community. 
+
+Example sessions:
+
+* "Getting Started with OpenSearch Deployment"  
+* "Basic Search Query Syntax"  
+* "Introduction to OpenSearch Dashboards"  
+* “Growing a collaborative open source community” 
+
+### 200-Level: Implementation & Development
+
+Target audience: Practitioners with hands-on OpenSearch experience who want to expand their capabilities and help grow the community.
+
+Content focus: Advanced querying techniques, cluster optimization, plugin development, and real-world use cases.
+
+Example sessions:
+
+* "Performance Tuning for Large-Scale Deployments"  
+* "Custom Plugin Development"  
+* "Advanced Aggregation Patterns"  
+* “Why content, and not just the docs, need more from the open source community”
+
+### 300-Level: Mastery
+
+Target audience: Search engine experts, core contributors, and system architects working on complex OpenSearch implementations.
+
+Content focus: Cutting-edge features, architectural deep-dives, performance at scale, and advanced security implementations.
+
+Example sessions:
+
+* "Building High-Performance Search Analytics Pipelines"  
+* "Security Monitoring of OpenSearch \- with OpenSearch"  
+* "Distributed Search Architecture Design Patterns"  
+* “Digging Into OpenSearch’s Memory: Lucene and JVM Garbage Collection Under the Microscope”
+
+Each level builds upon previous knowledge, creating a clear learning path from basic search operations to advanced distributed system architecture. Sessions include hands-on examples, real-world applications, and interactive Q\&A opportunities.  


### PR DESCRIPTION
### Description
OpenSearch Events: Session Level Guide

OpenSearch presentations are categorized into 100, 200, and 300 levels to help attendees choose sessions that match their expertise. Each level indicates the depth of technical knowledge required to effectively engage with the content.

This document provides guidance and examples for community members submitting to CFPs as well as insight for OpenSearchCon panelists to refer to when scoring talks. 

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
