### PR TITLE
Updates to maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @krisfreedain @nknize @dimwetoth @jhmcintyre @nateynateynate
+*   @krisfreedain @nknize @pawelw1 @jhmcintyre

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,6 +8,13 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | ---------------- | --------------------------------------------------- | ----------- |
 | Kris Freedain    | [krisfreedain](https://github.com/krisfreedain)     | Amazon      |
 | Nick Knize       | [nknize](https://github.com/nknize)                 | Lucenia     |
-| Daryll Swager    | [dimwetoth](https://github.com/dimwetoth)           | Amazon      |
+| Pawel Wlodarczyk | [pawelw1](https://github.com/pawelw1)               | Eliatra     |
 | James McIntyre   | [jhmcintyre](https://github.com/jhmcintyre)         | Amazon      |
-| Nate Boot        | [nateynateynate](https://github.com/nateynateynate) | Amazon      |
+
+
+## Emeritus
+
+| Maintainer            | GitHub ID                                               | Affiliation      |
+| --------------------- | ------------------------------------------------------- | ---------------- |
+| Daryll Swager         | [dimwetoth](https://github.com/dimwetoth)               | Amazon           |
+| Nate Boot             | [nateynateynate](https://github.com/nateynateynate)     | Amazon           |


### PR DESCRIPTION
### Description
Email results are in. 
Moving @dimwetoth & @nateynateynate to Emeritus status - thank you both for all your past work
Welcoming @pawelw1 as a new maintainer - looking forward to continuing to build community with you

### Issues Resolved
https://github.com/opensearch-project/community/issues/101

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
