### PR TITLE
Update the Organizers.md with Mumbai User Group entry

### DIFF
--- a/user-groups/ORGANIZERS.md
+++ b/user-groups/ORGANIZERS.md
@@ -203,6 +203,8 @@ The [OpenSearch User Group program](https://opensearch.org/user-groups/) is supp
 |---|---|---|---|
 | Chetna Sakarde | community | [chetna-sakarde](https://github.com/chetna-sakarde) | [LI](https://www.linkedin.com/in/chetnasakarde2006/) |
 | Gunjan Ghangare | community | [gunjan-ghangare](https://github.com/gunjan-ghangare) | [LI](https://www.linkedin.com/in/gunjanghangare/) |
+| Kris Freedain | Amazon | [krisfreedain](https://github.com/krisfreedain) | [LI](https://www.linkedin.com/in/krisfreedain) |
+
 
 ## [OpenSearch Project Nagpur](https://www.meetup.com/opensearch-project-nagpur/)
 

--- a/user-groups/ORGANIZERS.md
+++ b/user-groups/ORGANIZERS.md
@@ -197,6 +197,13 @@ The [OpenSearch User Group program](https://opensearch.org/user-groups/) is supp
 | David Bennett | Eliatra |  | [LI](https://www.linkedin.com/in/davidwbennett/) |
 | Kris Freedain | Amazon | [krisfreedain](https://github.com/krisfreedain) | [LI](https://www.linkedin.com/in/krisfreedain) |
 
+## [OpenSearch Project Mumbai](https://www.meetup.com/opensearch-project-mumbai/)
+
+| Organizer Name | Company | GitHub ID | LinkedIn |
+|---|---|---|---|
+| Chetna Sakarde | community | [chetna-sakarde](https://github.com/chetna-sakarde) | [LI](https://www.linkedin.com/in/chetnasakarde2006/) |
+| Gunjan Ghangare | community | [gunjan-ghangare](https://github.com/gunjan-ghangare) | [LI](https://www.linkedin.com/in/gunjanghangare/) |
+
 ## [OpenSearch Project Nagpur](https://www.meetup.com/opensearch-project-nagpur/)
 
 | Organizer Name | Company | GitHub ID | LinkedIn |


### PR DESCRIPTION
**Description**
Added the _**OpenSearch User Group Mumbai**_ entry to ORGANIZERS.md in alphabetical order, including organizers Gunjan Ghangare Chetna Sakarde And Kris Freedain with their company, GitHub, and LinkedIn details.

Issues Resolved
Adds the missing Mumbai user group organizer information to the community documentation.